### PR TITLE
Data recovery script

### DIFF
--- a/backend/lost/pyapi/examples/pipes/no_ai/.env
+++ b/backend/lost/pyapi/examples/pipes/no_ai/.env
@@ -1,0 +1,50 @@
+#=======================#
+#=   LOST Basic config  =#
+#=======================#
+DEBUG=False
+# Add example pipelines and example images =#
+ADD_EXAMPLES=False
+#= Add also ai pipelines if true. You will need the lost-cv worker to execute these pipelines.= #
+ADD_AI_EXAMPLES=False
+LOST_VERSION=1.4.2
+#= LOST port binding to host machine= #
+LOST_FRONTEND_PORT=80
+SECRET_KEY=DN8QW0ZLJO3YHXE1
+#= Path to LOST data in host filesystem= #
+LOST_DATA=/home/gbiziel/lost4/data
+#=======================#
+#= LOST Database config =#
+#=======================#
+LOST_DB_NAME=lost
+LOST_DB_USER=lost
+LOST_DB_PASSWORD=LostDbLost
+LOST_DB_ROOT_PASSWORD=LostRootLost
+#=======================#
+#=   PipeEngine config  =#
+#=======================#
+# Interval in seconds for the cronjob to update the pipeline= #
+PIPE_SCHEDULE=5
+# Intervall in seconds in which a worker should give a lifesign= #
+WORKER_BEAT=10
+# Timeout in seconds when a worker is considered to be dead= #
+WORKER_TIMEOUT=30
+# Session timout in minutes - timespan when an inactive user is logged out= #
+# Also used to schedule a background job that releases locked annotations = #
+SESSION_TIMEOUT=30
+#=========================#
+#= Your Mail config here =#
+#=========================#
+#MAIL_SERVER=mailserver.com
+#MAIL_PORT=465
+#MAIL_USE_SSL=True
+#MAIL_USE_TLS=True
+#MAIL_USERNAME=email@email.com
+#MAIL_PASSWORD=password
+#MAIL_DEFAULT_SENDER=LOST Notification System <email@email.com>
+#MAIL_LOST_URL=http://mylostinstance.url/
+
+# LOCAL configuration
+PY3_INIT=echo
+ENV_NAME=local
+WORKER_NAME=local
+LOST_DB_IP=127.0.0.1

--- a/backend/lost/pyapi/examples/pipes/no_ai/docker-compose.mysql.yml
+++ b/backend/lost/pyapi/examples/pipes/no_ai/docker-compose.mysql.yml
@@ -1,0 +1,17 @@
+version: '2.3'
+services:
+    db-lost:
+      image: mysql:5.7
+      container_name: db-lost
+      volumes:
+          - ${LOST_DATA}/mysql:/var/lib/mysql
+      restart: always
+      environment:
+          MYSQL_DATABASE: ${LOST_DB_NAME}
+          MYSQL_USER: ${LOST_DB_USER}
+          MYSQL_PASSWORD: ${LOST_DB_PASSWORD}
+          MYSQL_ROOT_PASSWORD: ${LOST_DB_ROOT_PASSWORD}
+      ports:
+        - "3306:3306"
+
+

--- a/backend/lost/pyapi/examples/pipes/no_ai/export_from_anno_task.py
+++ b/backend/lost/pyapi/examples/pipes/no_ai/export_from_anno_task.py
@@ -1,0 +1,49 @@
+import argparse
+
+from lost.db import model, access
+from lost.logic.config import LOSTConfig
+import pandas as pd
+
+
+def main(name_of_pipe: str = "WW16D2", file_name: str = 'annos_WW16D2.csv'):
+    """
+
+    Args:
+        name_of_pipe: Name of the pipe that needs triggered export.
+        file_name: Name of the file with exported bbox annotations
+
+    """
+    lostconfig = LOSTConfig()
+    dbm = access.DBMan(lostconfig)
+    pipe = dbm.session.query(model.Pipe) \
+        .filter(model.Pipe.name == name_of_pipe).first()
+    if pipe is None:
+        print("pipe was not found")
+        return
+    print(f"Reading: {pipe.name}")
+    anno_task = next((pe.anno_task for pe in pipe.pe_list if pe.anno_task is not None))
+    annotations = dbm.session.query(model.ImageAnno) \
+        .filter(model.ImageAnno.anno_task_id == anno_task.idx).all()
+    print(f'Images: {len(annotations)}')
+
+    df_list = []
+    for img_anno in annotations:
+        df_list.append(img_anno.to_df())
+    df = pd.concat(df_list)
+
+    print(f"Labels: {len(df)}")
+    df.to_csv(path_or_buf=file_name,
+              sep=',',
+              header=True,
+              index=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Recover annotations from a pipeline regardless of the pipeline's state.")
+    parser.add_argument('--pipe', action='store', default='WW16D2',
+                        help='Name of the pipe, e.g. WW16D2.')
+    parser.add_argument('--csv', action='store', default='annos_WW16D2.csv',
+                        help='Name of the output csv with annotations.')
+    args = parser.parse_args()
+    main(args.pipe, args.csv)


### PR DESCRIPTION
The script `export_from_anno_task.py` is for exporting annotations from a pipeline regardless of its state (e.g. when pipeline export crashed because it was too big on server).

The usage:
1) grab a mysql backup from our server
2) I'm using docker-compose.mysql.yml + .env file to spin the mysql instance (NOTE: some paths might need local adjustments)
3) Apply backup `mysql -u root -p mysql < backup_file.sql` (executing inside of running container)
4) Run script `export_from_anno_task.py --pipe=WW16D5 --csv=annost_WW16D5.csv`